### PR TITLE
Allow user to override the Go server host via an attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,10 +1,11 @@
 default[:go][:backup_path] = ""
 default[:go][:backup_retrieval_type] = "subversion"
 
-default[:go][:agent][:server_host]           = '127.0.0.1'
 default[:go][:agent][:auto_register]         = false
 default[:go][:agent][:auto_register_key]     = 'default_auto_registration_key'
 # Install this many agent instances on a box - default is one per CPU
 default[:go][:agent][:instance_count] = node[:cpu][:total]
+default[:go][:agent][:server_search_query] =
+  "chef_environment:#{node.chef_environment} AND run_list:recipe\\[go\\:\\:server\\]"
 
 default[:go][:version]                       = '13.4.1-18342'


### PR DESCRIPTION
This allows both chef-solo _and_ chef-client to set the Go server host IP. Chef-client will also output warnings if it can't find a Go server or if it finds more than one. If all else fails fall back on 127.0.0.1 as the Go server IP.

The Go server search query for chef-client is an attribute now. This lets wrapper cookbooks override the search criteria that works for their environment. In our infrastructure our Go server can be in a different Chef environment than the agents.
