### PR TITLE
Missing equals sign in agent_windows

### DIFF
--- a/recipes/agent_windows.rb
+++ b/recipes/agent_windows.rb
@@ -2,7 +2,7 @@ server_ip = node['go']['agent']['server_host']
 install_path = node['go']['agent']['install_path']
 
 opts = ""
-opts << "/SERVERIP #{server_ip}" if node['go']['agent']['server_host']
+opts << "/SERVERIP=#{server_ip}" if node['go']['agent']['server_host']
 opts << "/D=#{install_path}" if node['go']['agent']['install_path']
 
 download_url = node['go']['agent']['download_url']


### PR DESCRIPTION
According to documentation: https://github.com/gocd/gocd/blob/94237eb8d1136a89ee27fb401440adaa39d5b7e9/helper/topics/installing_go_agent.xml
