### PR TITLE
Change URL of APT repo to bintray

### DIFF
--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -6,8 +6,8 @@ when 'debian'
   include_recipe 'apt'
 
   apt_repository 'thoughtworks' do
-    uri 'http://download01.thoughtworks.com/go/debian'
-    components ['contrib/']
+    uri 'http://dl.bintray.com/gocd/gocd-deb/'
+    components ['/']
   end
 
   package_options = '--force-yes'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -3,8 +3,8 @@ when 'debian'
   include_recipe 'apt'
 
   apt_repository 'thoughtworks' do
-    uri 'http://download01.thoughtworks.com/go/debian'
-    components ['contrib/']
+    uri 'http://dl.bintray.com/gocd/gocd-deb/'
+    components ['/']
   end
 
   package_options = '--force-yes'


### PR DESCRIPTION
The old apt repo at `http://download01.thoughtworks.com` does not include recent versions of GO (only 14.1).

According to https://twitter.com/goforcd/status/511516616182747137 it is now at bintray.com

Fix the URI used to set up the `apt_repository`.
