### PR TITLE
Allow for configuration of apt/yum repo when installing on linux systems

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,3 +26,11 @@ suites:
   attributes: {"go":{"agent":{"auto_register_resources":["a", "b", "c"]}}}
   excludes:
     - centos-6.4
+- name: agent-v13
+  run_list: ['recipe[go::agent_linux]']
+  attributes: 
+    go:
+      version: '13.1.1-16714'
+      apt_repo: "http://download01.thoughtworks.com/go/debian"
+      apt_components": 
+        - 'contrib/'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,3 +17,18 @@ default['go']['version']                       = '14.2.0-377'
 unless platform?('windows')
   default['go']['agent']['java_home']             = '/usr/bin/java'
 end
+
+
+#set to old repo if version is 13
+if node['go']['version'] =~ /13\./
+	default['go']['apt_repository_url'] = 'http://download01.thoughtworks.com/go/debian'
+	default['go']['apt_repository_components'] = ['contrib/']
+
+	default['go']['yum_repository_url'] = 'http://download01.thoughtworks.com/go/yum/no-arch'
+else 
+	default['go']['apt_repository_url'] = 'http://download.go.cd/gocd-deb/'
+	default['go']['apt_repository_components'] = ['/']
+
+	default['go']['yum_repository_url'] = 'http://download.go.cd/gocd-rpm'
+end
+

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -6,8 +6,8 @@ when 'debian'
   include_recipe 'apt'
 
   apt_repository 'thoughtworks' do
-    uri 'http://download.go.cd/gocd-deb/'
-    components ['/']
+    uri node['go']['apt_repository_url']
+    components node['go']['apt_repository_components']
   end
 
   package_options = '--force-yes'
@@ -15,7 +15,7 @@ when 'rhel','fedora'
   include_recipe 'yum'
 
   yum_repository 'thoughtworks' do
-    baseurl 'http://download.go.cd/gocd-rpm'
+    baseurl node['go']['yum_repository_url']
     gpgcheck false
   end
 end
@@ -107,7 +107,8 @@ end
     variables(:go_server_host => go_server_host, 
       :go_server_port => '8153', 
       :java_home => node['java']['java_home'],
-      :work_dir => "/var/lib/go-agent#{suffix}")
+      :work_dir => "/var/lib/go-agent#{suffix}",
+      :go_agent_version => node['go']['version'])
   end
   
   template "/usr/share/go-agent/agent#{suffix}.sh" do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -3,8 +3,8 @@ when 'debian'
   include_recipe 'apt'
 
   apt_repository 'thoughtworks' do
-    uri 'http://download.go.cd/gocd-deb/'
-    components ['/']
+    uri node['go']['apt_repository_url']
+    components node['go']['apt_repository_components']
   end
 
   package_options = '--force-yes'
@@ -12,7 +12,7 @@ when 'rhel','fedora'
   include_recipe 'yum'
 
   yum_repository 'thoughtworks' do
-    baseurl 'http://download.go.cd/gocd-rpm'
+    baseurl node['go']['yum_repository_url']
     gpgcheck false
   end
 end

--- a/templates/default/go-agent-defaults.erb
+++ b/templates/default/go-agent-defaults.erb
@@ -1,3 +1,4 @@
+#GO Agent version <%= @go_agent_version %>
 export GO_SERVER=<%= @go_server_host %>
 export GO_SERVER_PORT=<%= @go_server_port %>
 export JAVA_HOME=<%= @java_home %>

--- a/test/integration/agent-v13/serverspec/agent_verify_spec.rb
+++ b/test/integration/agent-v13/serverspec/agent_verify_spec.rb
@@ -1,0 +1,19 @@
+require 'serverspec'
+
+include Serverspec::Helper::Exec
+include Serverspec::Helper::DetectOS
+
+describe "Go Agent Daemon" do
+  it "has a running service of go-agent" do
+    expect(service("go-agent")).to be_running
+  end
+end
+
+describe "GO Agent Config" do 
+  describe file('/etc/default/go-agent') do 
+  	it {should be_file}
+  	it {should be_readable}
+  	it { should contain 'GO Agent version 13.1.1-16714' }
+  end
+end
+

--- a/test/integration/default/serverspec/go_agent_daemon_spec.rb
+++ b/test/integration/default/serverspec/go_agent_daemon_spec.rb
@@ -16,4 +16,12 @@ describe "GO Agent Config" do
   	it { should contain 'agent.auto.register.key=default_auto_registration_key' }
   end
 
+describe file('/etc/default/go-agent') do 
+  	it {should be_file}
+  	it {should be_readable}
+  	it { should contain 'GO Agent version 14.2.0-377' }
+  end
+
 end
+
+


### PR DESCRIPTION
The update will check the version attribute, if is 13.x.x.x it will use the old repo, otherwise the new one is used.

There is an additional version 13 test with test-kitchen to verify the use of an older repo. The version string is added to the agent defaults file as a comment to be able to easily determine the version of the agent.

Default test has been updated to test for the current default version 14.2.0-377.
