### PR TITLE
Updating for serverspec 2.x

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,3 @@
 source 'https://supermarket.getchef.com'
 
 metadata
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,12 @@
 require 'foodcritic'
 require 'kitchen'
+require 'rubocop/rake_task'
 
 # Style tests. Rubocop and Foodcritic
 namespace :style do
+  desc 'Run Ruby style checks'
+  RuboCop::RakeTask.new(:ruby)
+
   desc 'Run Chef style checks'
   FoodCritic::Rake::LintTask.new(:chef) do |t|
     t.options = {
@@ -13,7 +17,7 @@ namespace :style do
 end
 
 desc 'Run all style checks'
-task style: ['style:chef']
+task style: ['style:ruby', 'style:chef']
 
 # Integration tests. Kitchen.ci
 namespace :integration do

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,34 +1,38 @@
 # linux_box_name = 'opscode_centos-5.9_chef-11.4.4'
 # linux_box_name = 'opscode-fedora-20'
 linux_box_name = 'opscode_ubuntu-12.04_chef-11.2.0'
-linux_box_url  = "https://opscode-vm.s3.amazonaws.com/vagrant/#{linux_box_name}.box"
-windows_box_name = 'vagrant-windows2008r2'
-windows_box_url = "http://PUTINYOURBOXSERVERHERE/vagrant/boxes/#{windows_box_name}.box"
+linux_box_url = 'https://opscode-vm.s3.amazonaws.com/' \
+  "vagrant/#{linux_box_name}.box"
+# windows_box_name = 'vagrant-windows2008r2'
+# windows_box_url = 'http://PUTINYOURBOXSERVERHERE/' \
+#   "vagrant/boxes/#{windows_box_name}.box"
 api_version = '2'
 
-Vagrant::configure(api_version) do |config|
+Vagrant.configure(api_version) do |config|
   config.berkshelf.enabled    = true
   config.omnibus.chef_version = :latest
-  
-  if Vagrant.has_plugin?("vagrant-cachier")
-      # Configure cached packages to be shared between instances of the same base box.
-      # More info on http://fgrehm.viewdocs.io/vagrant-cachier/usage
-      config.cache.scope = :box
 
-      # OPTIONAL: If you are using VirtualBox, you might want to use that to enable
-      # NFS for shared folders. This is also very useful for vagrant-libvirt if you
-      # want bi-directional sync
-      config.cache.synced_folder_opts = {
-        type: :nfs,
-        # The nolock option can be useful for an NFSv3 client that wants to avoid the
-        # NLM sideband protocol. Without this option, apt-get might hang if it tries
-        # to lock files needed for /var/cache/* operations. All of this can be avoided
-        # by using NFSv4 everywhere. Please note that the tcp option is not the default.
-        mount_options: ['rw', 'vers=3', 'tcp', 'nolock']
-      }
-      # For more information please check http://docs.vagrantup.com/v2/synced-folders/basic_usage.html
+  if Vagrant.has_plugin?('vagrant-cachier')
+    # Configure cached packages to be shared between instances of the
+    # same base box.
+    # More info on http://fgrehm.viewdocs.io/vagrant-cachier/usage
+    config.cache.scope = :box
+
+    # OPTIONAL: If you are using VirtualBox, you might want to use that
+    # to enable NFS for shared folders. This is also very useful for
+    # vagrant-libvirt if you want bi-directional sync
+    config.cache.synced_folder_opts = {
+      type: :nfs,
+      # The nolock option can be useful for an NFSv3 client that wants
+      # to avoid the NLM sideband protocol. Without this option, apt-get
+      # might hang if it tries to lock files needed for /var/cache/*
+      # operations. All of this can be avoided by using NFSv4 everywhere.
+      # Please note that the tcp option is not the default.
+      mount_options: ['rw', 'vers=3', 'tcp', 'nolock']
+    }
+    # For more information please check http://docs.vagrantup.com/v2/synced-folders/basic_usage.html
   end
-  
+
   config.vm.define 'linux', primary: true do |linux|
     linux.vm.box               = linux_box_name
     linux.vm.box_url           = linux_box_url
@@ -37,27 +41,28 @@ Vagrant::configure(api_version) do |config|
       v.customize ['modifyvm', :id, '--memory', '1024']
     end
 
-    linux.vm.network "forwarded_port", guest:8153, host: 8153
+    linux.vm.network 'forwarded_port', guest: 8153, host: 8153
 
     linux.vm.provision :chef_solo do |chef|
       chef.log_level = 'info'
       chef.json = {
-          'go' => {
-              'server' => '127.0.0.1',
-              'agent' => {
-                  'auto_register' => true,
-                  'instance_count' => 3
-              }
+        'go' => {
+          'server' => '127.0.0.1',
+          'agent' => {
+            'auto_register' => true,
+            'instance_count' => 3
           }
+        }
       }
 
       chef.run_list = [
-          'recipe[go]'
+        'recipe[go]'
       ]
     end
   end
 
-  # Berkshelf doesn't support multi-VM Vagrantfiles.  Will need to sort this out later.
+  # Berkshelf doesn't support multi-VM Vagrantfiles.  Will need to sort
+  # this out later.
   #
   # config.vm.define 'windows', autostart: false do |windows|
   #   windows.vm.box               = windows_box_name
@@ -69,7 +74,9 @@ Vagrant::configure(api_version) do |config|
   #
   #   windows.vm.guest = :windows
   #
-  #   windows.vm.network :forwarded_port, guest: 5985, host: 5985, auto_correct: true
+  #   windows.vm.network(
+  #     :forwarded_port, guest: 5985, host: 5985, auto_correct: true
+  #   )
   #
   #   windows.vm.network :private_network, ip: '192.168.192.3'
   #
@@ -88,5 +95,3 @@ Vagrant::configure(api_version) do |config|
   # end
 
 end
-
-  

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,8 +1,10 @@
+# Encoding: utf-8
+
 default['go']['backup_path'] = ''
 default['go']['backup_retrieval_type'] = 'subversion'
 
-default['go']['agent']['auto_register']         = false
-default['go']['agent']['auto_register_key']     = 'default_auto_registration_key'
+default['go']['agent']['auto_register'] = false
+default['go']['agent']['auto_register_key'] = 'default_auto_registration_key'
 default['go']['agent']['auto_register_resources'] = []
 default['go']['agent']['auto_register_environments'] = []
 
@@ -11,10 +13,9 @@ default['go']['agent']['auto_register_environments'] = []
 default['go']['agent']['instance_count'] = node['cpu']['total']
 default['go']['agent']['server_search_query'] =
   "chef_environment:#{node.chef_environment} AND recipes:go\\:\\:server"
-  
 
-default['go']['version']                       = '14.3.0-1186'
+default['go']['version'] = '14.3.0-1186'
 
 unless platform?('windows')
-  default['go']['agent']['java_home']             = '/usr/bin/java'
+  default['go']['agent']['java_home'] = '/usr/bin/java'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,18 +1,21 @@
-name             "go"
-description      "Installs/Configures Go servers and agents"
-version          "0.2.2"
+# Encoding: utf-8
+# rubocop:disable SingleSpaceBeforeFirstArg, Metrics/LineLength
 
-supports "ubuntu", ">= 12.04"
-supports "centos"
-supports "windows"
+name             'go'
+description      'Installs/Configures Go servers and agents'
+version          '0.2.2'
 
-recipe "go::server", "Installs and configures a Go server"
-recipe "go::agent", "Installs and configures a Go agent"
-recipe "go::default", "Installs and configures a Go server and agent on the same node, for windows just agent"
-recipe "go::agent_windows", "Installs and configures Windows Go agent"
-recipe "go::agent_linux", "Install and configures Linux Go agent"
+supports 'ubuntu', '>= 12.04'
+supports 'centos'
+supports 'windows'
 
-depends "apt", ">= 1.9.2"
-depends "java", ">= 1.10.0"
-depends "yum", ">= 3.0.0"
-depends "windows", ">= 1.2.6"
+recipe 'go::server', 'Installs and configures a Go server'
+recipe 'go::agent', 'Installs and configures a Go agent'
+recipe 'go::default', 'Installs and configures a Go server and agent on the same node, for windows just agent'
+recipe 'go::agent_windows', 'Installs and configures Windows Go agent'
+recipe 'go::agent_linux', 'Install and configures Linux Go agent'
+
+depends 'apt', '>= 1.9.2'
+depends 'java', '>= 1.10.0'
+depends 'yum', '>= 3.0.0'
+depends 'windows', '>= 1.2.6'

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -1,3 +1,4 @@
+# Encoding: utf-8
 # Cookbook Name:: go
 # Recipe:: agent
 

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -1,3 +1,4 @@
+# Encoding: utf-8
 # Cookbook Name:: go
 # Recipe:: agent_linux
 
@@ -11,7 +12,7 @@ when 'debian'
   end
 
   package_options = '--force-yes'
-when 'rhel','fedora'
+when 'rhel', 'fedora'
   include_recipe 'yum'
 
   yum_repository 'thoughtworks' do
@@ -22,42 +23,42 @@ end
 
 include_recipe 'java'
 
-package_url             = node['go']['agent']['package_url']
-package_checksum        = node['go']['agent']['package_checksum']
-go_server_autoregister  = node['go']['agent']['auto_register']
 autoregister_key        = node['go']['agent']['auto_register_key']
 server_search_query     = node['go']['agent']['server_search_query']
 
-package "go-agent" do
+package 'go-agent' do
   version node['go']['version']
   options package_options
 end
 
 # If running under solo or user specifed the server host, try and use that
 if Chef::Config['solo'] || node['go']['agent'].attribute?('server_host')
-  Chef::Log.info("Attempting to use node['go']['agent']['server_host'] attribute " +
-    "for server host")
+  Chef::Log.info("Attempting to use node['go']['agent']['server_host'] " \
+    'attribute for server host')
   go_server_host = node['go']['agent']['server_host']
 else
   # Running under client and user didn't specify a server_host attribute
   Chef::Log.info("Search query: #{server_search_query}")
   go_servers = search(:node, server_search_query)
   if go_servers.count == 0
-    Chef::Log.warn("No Go servers found on Chef server.")
+    Chef::Log.warn('No Go servers found on Chef server.')
   else
     go_server = go_servers[0]
     go_server_host = go_server['ipaddress']
     if go_servers.count > 1
-      Chef::Log.warn("Multiple Go servers found on Chef server. Using first returned server " +
-        "'#{go_server_host}' for server instance configuration.")
+      Chef::Log.warn('Multiple Go servers found on Chef server. Using first ' \
+        "returned server '#{go_server_host}' for server instance " \
+        'configuration.')
     end
     go_server_autoregister = go_server['go']['auto_register_agents']
-    Chef::Log.info("Found Go server at ip address #{go_server_host} with automatic agent registration=#{go_server_autoregister}")
-    if (go_server_autoregister)
-      Chef::Log.warn("Agent auto-registration enabled.  This agent will not require approval to become active.")
+    Chef::Log.info("Found Go server at ip address #{go_server_host} with " \
+                   "automatic agent registration=#{go_server_autoregister}")
+    if go_server_autoregister
+      Chef::Log.warn('Agent auto-registration enabled.  This agent will not ' \
+                     'require approval to become active.')
       autoregister_key = go_server['go']['autoregister_key']
     else
-      autoregister_key = ""
+      autoregister_key = ''
     end
   end
 end
@@ -65,13 +66,13 @@ end
 # Ensure we have a Go server host set to a sensible default
 if go_server_host.nil?
   go_server_host = '127.0.0.1'
-  Chef::Log.warn("Go server not found on Chef server or not specifed via " +
-    "node['go']['agent']['server_host'] attribute, defaulting Go server to #{go_server_host}")
+  Chef::Log.warn('Go server not found on Chef server or not specifed via ' \
+    "node['go']['agent']['server_host'] attribute, defaulting Go server " \
+    "to #{go_server_host}")
 end
 
-
-# Install & configure the initial (default) Go agent as it comes from the binary distribution
-# Then install any additional agents with -COUNT addition.
+# Install & configure the initial (default) Go agent as it comes from the
+# binary distribution. Then install any additional agents with -COUNT addition.
 # i.e.
 # /etc/default/go-agent
 #             /go-agent-2
@@ -83,20 +84,22 @@ end
 # default['go']['agent'][:instance_count] = node[:cpu][:total]
 
 (1..node['go']['agent']['instance_count']).each do |i|
-  log "Configuring Go agent # #{i} of #{node['go']['agent']['instance_count']} for Go server at #{go_server_host}:8153 "
-  if (i < 2)
-    suffix = ""
+  log "Configuring Go agent # #{i} of " \
+    "#{node['go']['agent']['instance_count']} for Go server at " \
+    "#{go_server_host}:8153 "
+  if i < 2
+    suffix = ''
   else
     suffix = "-#{i}"
   end
-  
+
   template "/etc/init.d/go-agent#{suffix}" do
     # <%= @go_agent_instance -%>
     source 'go-agent-service.erb'
     mode '0755'
     owner 'root'
     group 'root'
-    variables(:go_agent_instance => suffix)
+    variables(go_agent_instance: suffix)
   end
 
   template "/etc/default/go-agent#{suffix}" do
@@ -104,18 +107,18 @@ end
     mode '0644'
     owner 'go'
     group 'go'
-    variables(:go_server_host => go_server_host, 
-      :go_server_port => '8153', 
-      :java_home => node['java']['java_home'],
-      :work_dir => "/var/lib/go-agent#{suffix}")
+    variables(go_server_host: go_server_host,
+              go_server_port: '8153',
+              java_home: node['java']['java_home'],
+              work_dir: "/var/lib/go-agent#{suffix}")
   end
-  
+
   template "/usr/share/go-agent/agent#{suffix}.sh" do
     source 'go-agent-sh.erb'
     mode '0755'
     owner 'go'
     group 'go'
-    variables(:go_agent_instance => suffix)
+    variables(go_agent_instance: suffix)
   end
 
   log "Registering agent#{suffix} with autoregister key of " + autoregister_key
@@ -125,7 +128,6 @@ end
     owner 'go'
     group 'go'
   end
-
 
   directory "/var/lib/go-agent#{suffix}" do
     mode '0755'
@@ -138,7 +140,7 @@ end
     owner 'go'
     group 'go'
   end
-  
+
   autoregister_resources = []
   node['go']['agent']['auto_register_resources'].each do |resource_key|
     autoregister_resources.push(resource_key)
@@ -149,9 +151,13 @@ end
     autoregister_environments.push(env_key)
   end
 
-  autoregister_resources.push(node['os'], node['platform'], "#{node['platform']}-#{node['platform_version']}")
+  autoregister_resources.push(
+    node['os'], node['platform'],
+    "#{node['platform']}-#{node['platform_version']}"
+  )
 
-  log "Registering agent with resource tags: #{autoregister_resources} and environments: #{autoregister_environments}"
+  log "Registering agent with resource tags: #{autoregister_resources} and " \
+    "environments: #{autoregister_environments}"
 
   template "/var/lib/go-agent#{suffix}/config/autoregister.properties" do
     source 'autoregister.properties.erb'
@@ -159,23 +165,22 @@ end
     group 'go'
     owner 'go'
     variables(
-      :autoregister_key => autoregister_key,
-      :agent_resources => autoregister_resources.join(","),
-      :agent_environments => autoregister_environments.join(","))
+      autoregister_key: autoregister_key,
+      agent_resources: autoregister_resources.join(','),
+      agent_environments: autoregister_environments.join(','))
   end
-  
 
   service "go-agent#{suffix}" do
-    supports :status => true, :restart => true, :reload => true, :start => true
+    autoregister_properties_path = 'template[/var/lib/' \
+      "go-agent#{suffix}/config/autoregister.properties]"
+    supports status: true, restart: true, reload: true, start: true
     action :nothing
     subscribes :enable, "template[/etc/init.d/go-agent#{suffix}]"
-    subscribes :enable, "template[/var/lib/go-agent#{suffix}/config/autoregister.properties]"
+    subscribes :enable, autoregister_properties_path
     subscribes :enable, "template[/etc/default/go-agent#{suffix}]"
     subscribes :restart, "template[/etc/init.d/go-agent#{suffix}]"
-    subscribes :restart, "template[/var/lib/go-agent#{suffix}/config/autoregister.properties]"
+    subscribes :restart, autoregister_properties_path
     subscribes :restart, "template[/etc/default/go-agent#{suffix}]"
   end
-  
+
 end
-
-

--- a/recipes/agent_windows.rb
+++ b/recipes/agent_windows.rb
@@ -1,15 +1,17 @@
+# Encoding: utf-8
 
 server_ip = node['go']['agent']['server_host']
 install_path = node['go']['agent']['install_path']
 
-opts = ""
+opts = ''
 opts << "/SERVERIP=#{server_ip} " if node['go']['agent']['server_host']
 opts << "/D=#{install_path}" if node['go']['agent']['install_path']
 
 download_url = node['go']['agent']['download_url']
-if !download_url
+unless download_url
   major_ver = node['go']['version'].split('-', 2).first
-  download_url = "http://download01.thoughtworks.com/go/#{major_ver}/ga/go-agent-#{node['go']['version']}-setup.exe"
+  download_url = "http://download01.thoughtworks.com/go/#{major_ver}/ga/" \
+    "go-agent-#{node['go']['version']}-setup.exe"
 end
 
 windows_package 'Go Agent' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,12 +1,15 @@
-# Since we're running on a single node we can just use 127.0.0.1 for the server IP. Search isn't necessary
+# Encoding: utf-8
+
+# Since we're running on a single node we can just use 127.0.0.1 for
+# the server IP. Search isn't necessary
 
 case node['platform']
 when 'windows'
-  include_recipe "go::agent_windows"
+  include_recipe 'go::agent_windows'
 else
   node.default['go']['server'] = '127.0.0.1'
-  include_recipe "go::server"
-  include_recipe "go::agent_linux"
+  include_recipe 'go::server'
+  include_recipe 'go::agent_linux'
 end
 
 Chef::Log.info("Node has #{node['cpu']['total']} CPUs")

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,3 +1,5 @@
+# Encoding: utf-8
+
 case node['platform_family']
 when 'debian'
   include_recipe 'apt'
@@ -8,7 +10,7 @@ when 'debian'
   end
 
   package_options = '--force-yes'
-when 'rhel','fedora'
+when 'rhel', 'fedora'
   include_recipe 'yum'
 
   yum_repository 'thoughtworks' do
@@ -21,125 +23,143 @@ include_recipe 'java'
 
 package 'unzip'
 
-package "go-server" do
+package 'go-server' do
   version node['go']['version']
   options package_options
   notifies :start, 'service[go-server]', :immediately
 end
 
-# If we're upgrading an existing Go Server then leave the configuration and such intact. 
-# If it's a new node, and a SVN backup URL is specified then restore/overwrite any existing configuration.
+# If we're upgrading an existing Go Server then leave the configuration
+# and such intact.  If it's a new node, and a SVN backup URL is
+# specified then restore/overwrite any existing configuration.
 
-# Detection isn't based on the <license> element as Go-Community edition has no license. 
-# We look for at least one <pipelines> element, with the assumption that if you have a backup you have at least one pipeline.
+# Detection isn't based on the <license> element as Go-Community edition
+# has no license.
 
-if (::File.exists?('/etc/go/cruise-config.xml') and ::File.readlines('/etc/go/cruise-config.xml').grep(/<pipelines/).length > 0) 
+# We look for at least one <pipelines> element, with the assumption that
+# if you have a backup you have at least one pipeline.
+
+if ::File.exist?('/etc/go/cruise-config.xml') &&
+   ::File.readlines('/etc/go/cruise-config.xml').grep(/<pipelines/).length > 0
   skip_backup = true
-  Chef::Log.warn("Existing configuration detected. Restore skipped.")
+  Chef::Log.warn('Existing configuration detected. Restore skipped.')
 else
-  Chef::Log.warn("New install detected.")
+  Chef::Log.warn('New install detected.')
   skip_backup = false
   restore_go_config = false
-  if (node['go']['backup_path'] && !node['go']['backup_path'].strip.empty?) 
-    Chef::Log.warn("Backup URL specified. Configuration will be restored.")
+  if node['go']['backup_path'] && !node['go']['backup_path'].strip.empty?
+    Chef::Log.warn('Backup URL specified. Configuration will be restored.')
     restore_go_config = true
   end
 end
 
 if node['go']['backup_retrieval_type'] =~ /subversion|svn/i
-# Grab the backup out of Subversion
-  subversion "restore-go-config" do
+  # Grab the backup out of Subversion
+  subversion 'restore-go-config' do
     Chef::Log.info("Restoring configuration from #{node['go']['backup_path']}")
     repository node['go']['backup_path']
     destination "#{Chef::Config[:file_cache_path]}/go-config-restore"
     action :force_export
     notifies :stop, 'service[go-server-control]', :immediately
-    not_if {skip_backup}
-    only_if {restore_go_config}
+    not_if { skip_backup }
+    only_if { restore_go_config }
   end
-elsif node['go']['backup_retrieval_type'] =~ /local/i and ::File.directory?(node['go']['backup_path'])
-  directory "#{Chef::Config[:file_cache_path]}/go-config-restore/go-config/current" do
+elsif node['go']['backup_retrieval_type'] =~
+      /local/i && ::File.directory?(node['go']['backup_path'])
+  directory "#{Chef::Config[:file_cache_path]}/go-config-restore/" \
+      'go-config/current' do
     mode 0755
     recursive true
     action :create
   end
 
-  ruby_block "copy_local_file" do
+  ruby_block 'copy_local_file' do
     block do
-      if ::File.exists?("#{node['go']['backup_path']}/db.zip")
-        ::FileUtils.cp "#{node['go']['backup_path']}/db.zip", "#{Chef::Config[:file_cache_path]}/go-config-restore/go-config/current"
+      backup_dir = node['go']['backup_path']
+      restore_config_path = "#{Chef::Config[:file_cache_path]}/" \
+        'go-config-restore/go-config/current'
+
+      if ::File.exist?("#{backup_dir}/db.zip")
+        ::FileUtils.cp "#{backup_dir}/db.zip", restore_config_path
       end
-      if ::File.exists?("#{node['go']['backup_path']}/config-dir.zip")
-        ::FileUtils.cp "#{node['go']['backup_path']}/config-dir.zip", "#{Chef::Config[:file_cache_path]}/go-config-restore/go-config/current"
+      if ::File.exist?("#{backup_dir}/config-dir.zip")
+        ::FileUtils.cp "#{backup_dir}/config-dir.zip", restore_config_path
       end
-      if ::File.exists?("#{node['go']['backup_path']}/config-repo.zip")
-        ::FileUtils.cp "#{node['go']['backup_path']}/config-repo.zip", "#{Chef::Config[:file_cache_path]}/go-config-restore/go-config/current"
+      if ::File.exist?("#{backup_dir}/config-repo.zip")
+        ::FileUtils.cp "#{backup_dir}/config-repo.zip", restore_config_path
       end
     end
   end
 end
 
 # Trash and restore the H2 Database
-file "/var/lib/go-server/db/h2db/cruise.h2.db" do
+file '/var/lib/go-server/db/h2db/cruise.h2.db' do
   action :delete
-  not_if {skip_backup}
-  only_if {restore_go_config}
+  not_if { skip_backup }
+  only_if { restore_go_config }
 end
 
-execute "restore_db" do
-  Chef::Log.info("Restoring h2db")
-  command "unzip -q -u -o #{Chef::Config[:file_cache_path]}/go-config-restore/go-config/current/db.zip -d  /var/lib/go-server/db/h2db"
-  user "go"
-  group "go"
+execute 'restore_db' do
+  Chef::Log.info('Restoring h2db')
+  command "unzip -q -u -o #{Chef::Config[:file_cache_path]}" \
+          '/go-config-restore/go-config/current/db.zip' \
+          '-d /var/lib/go-server/db/h2db'
+  user 'go'
+  group 'go'
   action :run
-  not_if {skip_backup}
-  only_if {restore_go_config}
+  not_if { skip_backup }
+  only_if { restore_go_config }
 end
 
-# Trash and restore the /etc/go configuration.  Noted side-effect of this approach is that /etc/go is owned by Go, not root.
-directory "/etc/go" do
-  action :delete
-  recursive true
-  not_if {skip_backup}
-  only_if {restore_go_config}
-end
-directory "/etc/go" do
-  action :create
-  user "go"
-  group "go"
-  not_if {skip_backup}
-  only_if {restore_go_config}
-end
-execute "restore_config" do
-  command "unzip -q -u -o #{Chef::Config[:file_cache_path]}/go-config-restore/go-config/current/config-dir.zip -d  /etc/go"
-  user "go"
-  group "go"
-  action :run
-  not_if {skip_backup}
-  only_if {restore_go_config}
-end
-
-# Trash and restore the internal Git repo that's really the source of the pipeline config.  Once this completes fire up Go.
-directory "/var/lib/go-server/db/config.git" do
+# Trash and restore the /etc/go configuration.  Noted side-effect of
+# this approach is that /etc/go is owned by Go, not root.
+directory '/etc/go' do
   action :delete
   recursive true
-  not_if {skip_backup}
-  only_if {restore_go_config}
+  not_if { skip_backup }
+  only_if { restore_go_config }
 end
-directory "/var/lib/go-server/db/config.git" do
+directory '/etc/go' do
   action :create
-  user "go"
-  group "go"
-  not_if {skip_backup}
-  only_if {restore_go_config}
+  user 'go'
+  group 'go'
+  not_if { skip_backup }
+  only_if { restore_go_config }
 end
-execute "restore_config_repo" do
-  command "unzip -q -u -o #{Chef::Config[:file_cache_path]}/go-config-restore/go-config/current/config-repo.zip -d  /var/lib/go-server/db/config.git"
-  user "go"
-  group "go"
+execute 'restore_config' do
+  command "unzip -q -u -o #{Chef::Config[:file_cache_path]}" \
+          '/go-config-restore/go-config/current/config-dir.zip -d  /etc/go'
+  user 'go'
+  group 'go'
   action :run
-  not_if {skip_backup}
-  only_if {restore_go_config}
+  not_if { skip_backup }
+  only_if { restore_go_config }
+end
+
+# Trash and restore the internal Git repo that's really the source of the
+# pipeline config.  Once this completes fire up Go.
+directory '/var/lib/go-server/db/config.git' do
+  action :delete
+  recursive true
+  not_if { skip_backup }
+  only_if { restore_go_config }
+end
+directory '/var/lib/go-server/db/config.git' do
+  action :create
+  user 'go'
+  group 'go'
+  not_if { skip_backup }
+  only_if { restore_go_config }
+end
+execute 'restore_config_repo' do
+  command "unzip -q -u -o #{Chef::Config[:file_cache_path]}" \
+          '/go-config-restore/go-config/current/config-repo.zip' \
+          ' -d /var/lib/go-server/db/config.git'
+  user 'go'
+  group 'go'
+  action :run
+  not_if { skip_backup }
+  only_if { restore_go_config }
   notifies :restart, 'service[go-server]', :immediately
 end
 
@@ -151,7 +171,7 @@ end
 
 # Used for the lasting service config
 service 'go-server' do
-  supports :status => true, :restart => true, :reload => true, :start => true
+  supports status: true, restart: true, reload: true, start: true
   action [:enable, :nothing]
   notifies :get, 'http_request[verify_go-server_comes_up]', :immediately
 end
@@ -163,38 +183,45 @@ http_request 'verify_go-server_comes_up' do
   action :nothing
 end
 
-# Always run the publish/remove autoregister key blocks so that if the attribute gets changed dynamically we still work properly.
-# If it's not run every time we could leave the autoregister key in the attributes which would be bad.  Mmm'kay?
+# Always run the publish/remove autoregister key blocks so that if the
+# attribute gets changed dynamically we still work properly.  If it's not
+# run every time we could leave the autoregister key in the attributes
+# which would be bad.  Mmm'kay?
 
-if (Chef::Config[:solo])
-  Chef::Log.warn("Automatic agent registration is not supported on chef-solo.  All attributes must be set on the agent node directly.")
+if Chef::Config[:solo]
+  Chef::Log.warn('Automatic agent registration is not supported on ' \
+                 'chef-solo.  All attributes must be set on the agent node ' \
+                 'directly.')
 end
 
-ruby_block "publish_autoregister_key" do
+ruby_block 'publish_autoregister_key' do
   block do
-    s = ::File.readlines('/etc/go/cruise-config.xml').grep(/agentAutoRegisterKey="(\S+)"/)
-    if (s.length > 0)
-      server_autoregister_key=s[0].to_s.match(/agentAutoRegisterKey="(\S+)"/)[1]
+    s = ::File.readlines('/etc/go/cruise-config.xml')
+        .grep(/agentAutoRegisterKey="(\S+)"/)
+    if s.length > 0
+      server_autoregister_key =
+        s[0].to_s.match(/agentAutoRegisterKey="(\S+)"/)[1]
     else
-      server_autoregister_key=""
+      server_autoregister_key = ''
     end
 
-    Chef::Log.warn("Enabling automatic agent registration.  Any configured agent will be configured to build without authorization.")
-    node.set['go']['autoregister_key']=server_autoregister_key
+    Chef::Log.warn('Enabling automatic agent registration.  Any configured ' \
+                   'agent will be configured to build without authorization.')
+    node.set['go']['autoregister_key'] = server_autoregister_key
     node.save
   end
   action :create
-  only_if {node['go']['auto_register_agents']}
-  not_if {Chef::Config[:solo]}
+  only_if { node['go']['auto_register_agents'] }
+  not_if { Chef::Config[:solo] }
 end
 
-ruby_block "remove_autoregister_key" do
+ruby_block 'remove_autoregister_key' do
   block do
-    Chef::Log.warn("Disabling automatic agent registration.")
-    node.set['go']['autoregister_key']=""
+    Chef::Log.warn('Disabling automatic agent registration.')
+    node.set['go']['autoregister_key'] = ''
     node.save
   end
   action :create
-  not_if {node['go']['auto_register_agents']}
-  not_if {Chef::Config[:solo]}
+  not_if { node['go']['auto_register_agents'] }
+  not_if { Chef::Config[:solo] }
 end

--- a/test/integration/custom_agent_resources/serverspec/go_agent_deamon_spec.rb
+++ b/test/integration/custom_agent_resources/serverspec/go_agent_deamon_spec.rb
@@ -1,22 +1,26 @@
+# Telling rubocop to allow long lines, as the tests are more readable
+# as single, albiet long, lines than as do/end blocks.
+# rubocop:disable Metrics/LineLength
+
 require 'serverspec'
 
 # Required by serverspec
 set :backend, :exec
 
-describe "Go Agent Daemon" do
+describe 'Go Agent Daemon' do
 
-  it "has a running service of go-agent" do
-    expect(service("go-agent")).to be_running
+  it 'has a running service of go-agent' do
+    expect(service('go-agent')).to be_running
   end
 end
 
-describe "GO Agent Config" do 
-  describe file('/var/lib/go-agent/config/autoregister.properties') do 
-  	it {should be_file}
-  	it {should be_readable}
-  	it { should contain 'agent.auto.register.key=default_auto_registration_key' }
-  	it { should contain 'agent.auto.register.resources=a,b,c,linux,ubuntu,ubuntu-' }
-  	it { should contain 'agent.auto.register.environments=x,y,z' }
+describe 'GO Agent Config' do
+  describe file('/var/lib/go-agent/config/autoregister.properties') do
+    it { should be_file }
+    it { should be_readable }
+    it { should contain 'agent.auto.register.key=default_auto_registration_key' }
+    it { should contain 'agent.auto.register.resources=a,b,c,linux,ubuntu,ubuntu-' }
+    it { should contain 'agent.auto.register.environments=x,y,z' }
   end
 
 end

--- a/test/integration/default/serverspec/go_agent_daemon_spec.rb
+++ b/test/integration/default/serverspec/go_agent_daemon_spec.rb
@@ -1,20 +1,24 @@
+# Telling rubocop to allow long lines, as the tests are more readable
+# as single, albiet long, lines than as do/end blocks.
+# rubocop:disable Metrics/LineLength
+
 require 'serverspec'
 
 # Required by serverspec
 set :backend, :exec
 
-describe "Go Agent Daemon" do
+describe 'Go Agent Daemon' do
 
-  it "has a running service of go-agent" do
-    expect(service("go-agent")).to be_running
+  it 'has a running service of go-agent' do
+    expect(service('go-agent')).to be_running
   end
 end
 
-describe "GO Agent Config" do 
-  describe file('/var/lib/go-agent/config/autoregister.properties') do 
-  	it {should be_file}
-  	it {should be_readable}
-  	it { should contain 'agent.auto.register.key=default_auto_registration_key' }
+describe 'GO Agent Config' do
+  describe file('/var/lib/go-agent/config/autoregister.properties') do
+    it { should be_file }
+    it { should be_readable }
+    it { should contain 'agent.auto.register.key=default_auto_registration_key' }
   end
 
 end

--- a/test/integration/default/serverspec/go_server_daemon_spec.rb
+++ b/test/integration/default/serverspec/go_server_daemon_spec.rb
@@ -1,16 +1,20 @@
+# Telling rubocop to allow long lines, as the tests are more readable
+# as single, albiet long, lines than as do/end blocks.
+# rubocop:disable Metrics/LineLength
+
 require 'serverspec'
 
 # Required by serverspec
 set :backend, :exec
 
-describe "Go Server Daemon" do
+describe 'Go Server Daemon' do
 
   # it "is listening on port 8153" do
   #   expect(port(8153)).to be_listening
   # end
 
-  it "has a running service of go-server" do
-    expect(service("go-server")).to be_running
+  it 'has a running service of go-server' do
+    expect(service('go-server')).to be_running
   end
 
 end


### PR DESCRIPTION
Backend helper and DetectOS have been removed in serverspec 2.x. Details about half way down this page: http://serverspec.org/changes-of-v2.html
