### PR TITLE
added instruction for go server start with recipe in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It's primarily tested on newer versions of Ubuntu, but should work on both Debia
 go::server will install and start an empty Go server.
 
 Before running chef-client with this recipe , ensure you have the
-following setting on your server else server start will fail
+following setting on your ci-server else Go server start will fail
 
 $ hostname 
 <server-hostname>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ It's primarily tested on newer versions of Ubuntu, but should work on both Debia
 
 go::server will install and start an empty Go server.
 
+Before running chef-client with this recipe , ensure you have the
+following setting on your server else server start will fail
+
+$ hostname 
+<server-hostname>
+
+$ vim /etc/hosts
+127.0.0.1 <server-hostname>
+
 # Go Agent
 
 ## Linux


### PR DESCRIPTION
go:server installs and tries to start the go server.
If hostname is not setup on the ci-server , go server start fails. 
Added steps in read me to do before running chef-client with go:server recipe to help users.