### PR TITLE
#50 support installation from custom repository or package file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,44 @@
 # Go Cookbook
 
 Hello friend! This cookbook is here to help you setup Go servers and agents
-in an automated way. 
+in an automated way.
 
 It's primarily tested on newer versions of Ubuntu, but should work on both Debian and Red Hat based distributions.  There is also basic support for agents on Windows (enhancements appreciated!).
 
+## Install method
+
+### Repository
+
+By default installation source is done from apt or yum repositories from official sources at http://www.go.cd/download/.
+
+The **apt** repository can be overriden by changing any these attributes:
+```ruby
+default['gocd']['repository']['apt']['uri'] = 'http://download.go.cd/gocd-deb/'
+default['gocd']['repository']['apt']['components'] = [ '/' ]
+default['gocd']['repository']['apt']['package_options'] = '--force-yes'
+default['gocd']['repository']['apt']['keyserver'] = 'pgp.mit.edu'
+default['gocd']['repository']['apt']['key'] = '0x9149B0A6173454C7'
+```
+The **yum** repository can be overriden by changing any these attributes:
+```ruby
+default['gocd']['repository']['yum']['baseurl'] = 'http://download.go.cd/gocd-rpm'
+default['gocd']['repository']['yum']['gpgcheck'] = false
+```
+
+### From remote file
+
+Cookbook can skip adding repository and install Go server or agent by downloading a remote file and install it directly via `dpkg` or `rpm`.
+
+Change install method to 'package_file':
+```ruby
+node['gocd']['install_method'] = 'remote_file'
+```
+
+And assign base url where packages are available for download
+```ruby
+node['gocd']['package_file']['baseurl'] = 'http://my/custom/url'
+```
+The final download URL of file is built based on platform and `node['gocd']['version']`. E.g. `http://my/custom/url/go-agent-15.2.0-2520.deb`
 
 ## Ideas
 
@@ -33,10 +67,11 @@ You can use Vagrant and your own chef bootstrapped virtual box base image and va
 go recipe will install and configure a Windows Go agent on a Windows os, and associate it with an existing Go server.  Does not automatically register agent.
 
 Overrides available for go::agent_windows
-[:gocd][:agent][:server_host] - hostname or ip of Go server
-[:gocd][:agent][:install_path] - installation path for Go agent
-[:gocd][:agent][:java_home] - java home path if using existing java installation
-[:gocd][:agent][:download_url] - msi for agent install, if left empty will build download url using [:gocd][:version]
+ * `node[:gocd][:agent][:server_host]` - hostname or ip of Go server
+ * `node[:gocd][:agent][:install_path]` - installation path for Go agent
+ * `node[:gocd][:agent][:java_home]` - java home path if using existing java installation
+ * `node[:gocd][:agent][:download_url]` - msi for agent install, if left empty will build download url using `node[:gocd][:version]`
+
 
 # Authors
 Author:: Chris Kozak (<ckozak@gmail.com>)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,3 +21,35 @@ unless platform?('windows')
 end
 
 default['gocd']['server']['install_path'] = 'C:\Program Files (x86)\Go Server'
+
+default['gocd']['install_method'] = 'repository'
+
+default['gocd']['repository']['apt']['uri'] = 'http://download.go.cd/gocd-deb/'
+default['gocd']['repository']['apt']['components'] = [ '/' ]
+default['gocd']['repository']['apt']['package_options'] = '--force-yes'
+default['gocd']['repository']['apt']['keyserver'] = 'pgp.mit.edu'
+default['gocd']['repository']['apt']['key'] = '0x9149B0A6173454C7'
+
+default['gocd']['repository']['yum']['baseurl'] = 'http://download.go.cd/gocd-rpm'
+default['gocd']['repository']['yum']['gpgcheck'] = false
+
+version = node['gocd']['version']
+case node['platform_family']
+when 'debian'
+  default['gocd']['server']['package_file']['filename'] = "go-server-#{version}.deb"
+  default['gocd']['agent']['package_file']['filename'] = "go-agent-#{version}.deb"
+  default['gocd']['package_file']['baseurl'] = 'http://download.go.cd/gocd-deb/'
+when 'rhel','fedora'
+  default['gocd']['server']['package_file']['filename'] = "go-server-#{version}.noarch.rpm"
+  default['gocd']['agent']['package_file']['filename'] = "go-agent-#{version}.noarch.rpm"
+  default['gocd']['package_file']['baseurl'] = 'http://download.go.cd/gocd-rpm/'
+end
+
+default['gocd']['server']['package_file']['path'] =
+  File.join(Chef::Config[:file_cache_path], node['gocd']['server']['package_file']['filename'])
+default['gocd']['server']['package_file']['url'] =
+  "#{node['gocd']['package_file']['baseurl']}/#{node['gocd']['server']['package_file']['filename']}"
+default['gocd']['agent']['package_file']['path'] =
+  File.join(Chef::Config[:file_cache_path], node['gocd']['agent']['package_file']['filename'])
+default['gocd']['agent']['package_file']['url'] =
+  "#{node['gocd']['package_file']['baseurl']}/#{node['gocd']['agent']['package_file']['filename']}"

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -1,38 +1,40 @@
 # Cookbook Name:: go
 # Recipe:: agent_linux
 
-case node['platform_family']
-when 'debian'
-  include_recipe 'apt'
-
-  apt_repository 'thoughtworks' do
-    uri 'http://dl.bintray.com/gocd/gocd-deb/'
-    keyserver "pgp.mit.edu"
-    key "0x9149B0A6173454C7"
-    components ['/']
-  end
-
-  package_options = '--force-yes'
-when 'rhel','fedora'
-  include_recipe 'yum'
-
-  yum_repository 'thoughtworks' do
-    baseurl 'http://dl.bintray.com/gocd/gocd-rpm/'
-    gpgcheck false
-  end
-end
+include_recipe 'go::repository'
 
 include_recipe 'java'
 
-package_url             = node['gocd']['agent']['package_url']
-package_checksum        = node['gocd']['agent']['package_checksum']
 go_server_autoregister  = node['gocd']['agent']['auto_register']
 autoregister_key        = node['gocd']['agent']['auto_register_key']
 server_search_query     = node['gocd']['agent']['server_search_query']
 
-package "go-agent" do
-  version node['gocd']['version']
-  options package_options
+case node['gocd']['install_method']
+when 'repository'
+  include_recipe 'go::repository'
+  package_options = node['gocd']['repository']['apt']['package_options'] if node['platform_family'] == 'debian'
+  package "go-agent" do
+    version node['gocd']['version']
+    options package_options
+  end
+when 'package_file'
+  remote_file node['gocd']['agent']['package_file']['filename'] do
+    path node['gocd']['agent']['package_file']['path']
+    source node['gocd']['agent']['package_file']['url']
+    mode 0644
+  end
+  case node['platform_family']
+  when 'debian'
+    dpkg_package 'go-agent' do
+      source node['gocd']['agent']['package_file']['path']
+    end
+  when 'rhel','fedora'
+    rpm_package 'go-agent' do
+      source node['gocd']['agent']['package_file']['path']
+    end
+  end
+else
+  fail "Unknown install method - '#{node['gocd']['install_method']}'"
 end
 
 # If running under solo or user specifed the server host, try and use that
@@ -91,7 +93,7 @@ end
   else
     suffix = "-#{i}"
   end
-  
+
   template "/etc/init.d/go-agent#{suffix}" do
     # <%= @go_agent_instance -%>
     source 'go-agent-service.erb'
@@ -106,12 +108,12 @@ end
     mode '0644'
     owner 'go'
     group 'go'
-    variables(:go_server_host => go_server_host, 
-      :go_server_port => '8153', 
+    variables(:go_server_host => go_server_host,
+      :go_server_port => '8153',
       :java_home => node['java']['java_home'],
       :work_dir => "#{node['gocd']['agent']['work_dir_path']}/go-agent#{suffix}")
   end
-  
+
   template "/usr/share/go-agent/agent#{suffix}.sh" do
     source 'go-agent-sh.erb'
     mode '0755'
@@ -139,7 +141,7 @@ end
     owner 'go'
     group 'go'
   end
-  
+
   autoregister_resources = []
   node['gocd']['agent']['auto_register_resources'].each do |resource_key|
     autoregister_resources.push(resource_key)

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -1,0 +1,17 @@
+case node['platform_family']
+when 'debian'
+  include_recipe 'apt'
+
+  apt_repository 'thoughtworks' do
+    uri node['gocd']['repository']['apt']['uri']
+    keyserver node['gocd']['repository']['apt']['keyserver']
+    key node['gocd']['repository']['apt']['key']
+    components node['gocd']['repository']['apt']['components']
+  end
+when 'rhel','fedora'
+  include_recipe 'yum'
+  yum_repository 'thoughtworks' do
+    baseurl node['gocd']['repository']['yum']['baseurl']
+    gpgcheck node['gocd']['repository']['yum']['gpgcheck']
+  end
+end

--- a/recipes/server_linux.rb
+++ b/recipes/server_linux.rb
@@ -1,46 +1,50 @@
-case node['platform_family']
-when 'debian'
-  include_recipe 'apt'
-
-  apt_repository 'thoughtworks' do
-    uri 'http://download.go.cd/gocd-deb/'
-    components ['/']
-  end
-
-  package_options = '--force-yes'
-when 'rhel','fedora'
-  include_recipe 'yum'
-
-  yum_repository 'thoughtworks' do
-    baseurl 'http://download.go.cd/gocd-rpm'
-    gpgcheck false
-  end
-end
-
 include_recipe 'java'
 
 package 'unzip'
 
-package "go-server" do
-  version node['gocd']['version']
-  options package_options
-  notifies :start, 'service[go-server]', :immediately
+case node['gocd']['install_method']
+when 'repository'
+  include_recipe 'go::repository'
+  package_options = node['gocd']['repository']['apt']['package_options'] if node['platform_family'] == 'debian'
+  package "go-server" do
+    version node['gocd']['version']
+    options package_options
+    notifies :start, 'service[go-server]', :immediately
+  end
+when 'package_file'
+  remote_file node['gocd']['server']['package_file']['filename'] do
+    path node['gocd']['server']['package_file']['path']
+    source node['gocd']['server']['package_file']['url']
+    mode 0644
+  end
+  case node['platform_family']
+  when 'debian'
+    dpkg_package 'go-server' do
+      source node['gocd']['server']['package_file']['path']
+    end
+  when 'rhel','fedora'
+    rpm_package 'go-server' do
+      source node['gocd']['server']['package_file']['path']
+    end
+  end
+else
+  fail "Unknown install method - '#{node['gocd']['install_method']}'"
 end
 
-# If we're upgrading an existing Go Server then leave the configuration and such intact. 
+# If we're upgrading an existing Go Server then leave the configuration and such intact.
 # If it's a new node, and a SVN backup URL is specified then restore/overwrite any existing configuration.
 
-# Detection isn't based on the <license> element as Go-Community edition has no license. 
+# Detection isn't based on the <license> element as Go-Community edition has no license.
 # We look for at least one <pipelines> element, with the assumption that if you have a backup you have at least one pipeline.
 
-if (::File.exists?('/etc/go/cruise-config.xml') and ::File.readlines('/etc/go/cruise-config.xml').grep(/<pipelines/).length > 0) 
+if (::File.exists?('/etc/go/cruise-config.xml') and ::File.readlines('/etc/go/cruise-config.xml').grep(/<pipelines/).length > 0)
   skip_backup = true
   Chef::Log.warn("Existing configuration detected. Restore skipped.")
 else
   Chef::Log.warn("New install detected.")
   skip_backup = false
   restore_go_config = false
-  if (node['gocd']['backup_path'] && !node['gocd']['backup_path'].strip.empty?) 
+  if (node['gocd']['backup_path'] && !node['gocd']['backup_path'].strip.empty?)
     Chef::Log.warn("Backup URL specified. Configuration will be restored.")
     restore_go_config = true
   end


### PR DESCRIPTION
Refactored adding apt or rpm repository to separate recipe intead of
repeating code in agent and server recipe

Added possible installation from remote_file.

Default install method is still thoughtworks repository

Updated and fixed readme