### PR TITLE
Default to using latest version, when using a platform that supports it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1
+
+* Default to using latest version, when using a platform that supports it
+
 # 1.1.0
 
 * Improve support for installing GoCD on windows

--- a/attributes/repository.rb
+++ b/attributes/repository.rb
@@ -12,7 +12,12 @@ default['gocd']['repository']['yum']['baseurl'] = node['gocd']['download']['base
 default['gocd']['repository']['yum']['gpgcheck'] = true
 default['gocd']['repository']['yum']['gpgkey'] = 'https://download.go.cd/GOCD-GPG-KEY.asc'
 
-default['gocd']['version'] = '16.1.0-2855'
+case node['gocd']['install_method']
+when 'repository'
+# version = nil so just pick latest available
+else
+  default['gocd']['version'] = '16.2.1-3027'
+end
 
 version = node['gocd']['version']
 os_dir = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,6 @@
 name             "gocd"
 description      "Installs/Configures Go servers and agents"
-version          "1.1.0"
+version          "1.1.1"
 
 supports "ubuntu"
 supports "centos"


### PR DESCRIPTION
Require windows users to explicitly specify a version