### PR TITLE
added ability to add extra lines to init defaults file

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -2,12 +2,14 @@ default['gocd']['agent']['go_server_host'] = nil
 default['gocd']['agent']['go_server_port'] = 8153
 default['gocd']['agent']['daemon']         = true
 
-default['gocd']['agent']['vnc']['enabled']  = false
+default['gocd']['agent']['vnc']['enabled'] = false
 
 default['gocd']['agent']['autoregister']['key']          = nil
 default['gocd']['agent']['autoregister']['environments'] = %w()
 default['gocd']['agent']['autoregister']['resources']    = %w()
 default['gocd']['agent']['autoregister']['hostname']     = node['fqdn']
+
 default['gocd']['agent']['server_search_query'] = "chef_environment:#{node.chef_environment} AND recipes:gocd\\:\\:server"
-default['gocd']['agent']['workspace'] = nil # '/var/lib/go-agent' on linux
-default['gocd']['agent']['count'] = 1
+default['gocd']['agent']['workspace']           = nil # '/var/lib/go-agent' on linux
+default['gocd']['agent']['count']               = 1
+default['gocd']['agent']['default_extras']      = {}

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -7,3 +7,4 @@ default['gocd']['server']['work_dir']     = "/var/lib/go-server"
 
 default['gocd']['server']['wait_up']['retry_delay'] = 10
 default['gocd']['server']['wait_up']['retries']     = 10
+default['gocd']['server']['default_extras']         = {}

--- a/templates/default/go-agent-default.erb
+++ b/templates/default/go-agent-default.erb
@@ -8,3 +8,6 @@ export JAVA_HOME=<%=      node['java']['java_home'] %>
 export AGENT_WORK_DIR=<%= @workspace %>
 DAEMON=<%=  @daemon ? 'Y' : 'N' %>
 VNC=<%=     @vnc ? 'Y' : 'N' %>
+<% node['gocd']['agent']['default_extras'].each do |k, v| %>
+<%= k %>="<%= v %>"
+<% end %>

--- a/templates/default/go-server-default.erb
+++ b/templates/default/go-server-default.erb
@@ -15,3 +15,6 @@ export JAVA_HOME=<%=            node['java']['java_home'] %>
 
 DAEMON=Y
 ENABLE_PLUGINS=Y
+<% node['gocd']['server']['default_extras'].each do |k, v| %>
+<%= k %>="<%= v %>"
+<% end %>


### PR DESCRIPTION
I want to enable ipv4 by adding the following line to the defaults file:
```'export _JAVA_OPTIONS="-Djava.net.preferIPv4Stack=true"```
But actually others might want to customise some of the variables the init script uses and the shell script, so i thought id add a more flexible option.