### PR TITLE
Chef 13 Syntax Change in agent resource

### DIFF
--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -5,7 +5,7 @@ default_action :create if defined?(default_action)
 
 attribute :service_action, :kind_of => [ Symbol, Array ], :required => false, :default => [:enable,:start]
 
-attribute :agent_name, :name_attribute => true, :kind_of => String, :required => false, :default => 'go-agent'
+attribute :agent_name, :name_attribute => true, :kind_of => String, :required => false
 
 attribute :user, :kind_of => String, :required => false, :default => 'go'
 attribute :group, :kind_of => String, :required => false, :default => 'go'


### PR DESCRIPTION
When running this cookbook you get a deprecation warning:

```sh
Deprecated features used!
==> server:   Cannot specify both default and name_property together on property agent_name of resource gocd_agent. Only one (name_property) will be obeyed. In Chef 13, this will become an error. Please remove one or the other from the property. at 1 location:
==> server:     - /var/chef/cache/cookbooks/gocd/resources/agent.rb:8:in `class_from_file'
```

This pull fixes the issue described so it won't error out in Chef 13.