### PR TITLE
Fix various server installation errors on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The cookbook provides the following attributes to configure the GoCD server:
 * `node['gocd']['server']['max_mem']`      - The server maximum JVM heap space. Defaults to `2048m`.
 * `node['gocd']['server']['min_mem']`      - The server mimimum JVM heap space. Defaults to `1024m`.
 * `node['gocd']['server']['max_perm_gen']` - The server maximum JVM permgen space. Defaults to `400m`.
-* `node['gocd']['server']['work_dir']`     - The server working directory. Defaults to `/var/lib/go-server`.
+* `node['gocd']['server']['work_dir']`     - The server working directory. Defaults to `/var/lib/go-server` on linux, `C:\GoServer` on Windows.
 
 Chef cookbook waits for server to become responsive after restarting service.
 These attributes can be used to tune it:

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -5,6 +5,10 @@ default['gocd']['server']['min_mem']      = "1024m"
 default['gocd']['server']['max_perm_gen'] = "400m"
 default['gocd']['server']['work_dir']     = "/var/lib/go-server"
 
+if platform?('windows')
+	default['gocd']['server']['work_dir']     = 'C:\GoServer'
+end
+
 default['gocd']['server']['wait_up']['retry_delay'] = 10
 default['gocd']['server']['wait_up']['retries']     = 10
 default['gocd']['server']['default_extras']         = {}

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -50,7 +50,7 @@ module Gocd
 
     def go_server_config_file
       if platform?('windows')
-        'C:\Program Files\Go Server\config\cruise-config.xml'
+        "#{node['gocd']['server']['work_dir']}\\config\\cruise-config.xml"
       else
         '/etc/go/cruise-config.xml'
       end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -34,4 +34,5 @@ ruby_block "publish_autoregister_key" do
   end
   action :create
   not_if { Chef::Config[:solo] }
+  retries 4
 end

--- a/recipes/server_windows_install.rb
+++ b/recipes/server_windows_install.rb
@@ -7,7 +7,7 @@ end
 
 opts = []
 opts << '/S'
-opts << '/D=C:\GoServer'
+opts << "/D=#{node['gocd']['server']['work_dir']}"
 
 if defined?(Chef::Provider::Package::Windows)
   package 'Go Server' do


### PR DESCRIPTION
Right now the server portion of the cookbook will 100% not install on windows.

The windows server is hardcoded to install to C:\GoServer. This does not respect work_dir. I fixed that.

In helpers.rb I fixed the config path, its hard coded to point to C:\Program Files\Go Server (even though the server is hard coded to install to C:\GoServer, whats up with that?). I fixed it so that it respects work_dir and will actually find the config instead of pointing to a file that doesn't exist.

Work_Dir does not have a windows friendly default setting. I added some logic to set a default attribute to C:\GoServer if its on windows. I updated the documentation with this info.

Finally, "publish_autoregister_key" doesn't always get the config on the first try. It's a race condition I think, but i'm not positive. I worked around it by adding retries to the logic for now.