### PR TITLE
Fix GO_SERVER_URL not being set correctly on windows.

### DIFF
--- a/recipes/agent_windows_install.rb
+++ b/recipes/agent_windows_install.rb
@@ -13,7 +13,7 @@ if autoregister_values[:go_server_url].nil?
 end
 
 opts = []
-opts << "/SERVERURL=#{autoregister_values[:go_server_url]}"
+opts << "/SERVERURL='#{autoregister_values[:go_server_url]}'"
 opts << "/S"
 opts << '/D=C:\GoAgent'
 


### PR DESCRIPTION
When the agent is installed on windows, the GO_SERVER_URL gets set to "https:" instead of say "https://localhost/go" because of the quoting on the /SERVERURL= switch.