### PR TITLE
Fix Autoregister creation on windows

### DIFF
--- a/resources/agent_autoregister_file.rb
+++ b/resources/agent_autoregister_file.rb
@@ -22,13 +22,21 @@ action :create do
   autoregister_values[:elastic_agent_id] = new_resource.elastic_agent_id || autoregister_values[:elastic_agent_id]
   autoregister_values[:elastic_agent_plugin_id] = new_resource.elastic_agent_plugin_id || autoregister_values[:elastic_agent_plugin_id]
 
-  template new_resource.path do
-    source  'autoregister.properties.erb'
-    cookbook 'gocd'
-    mode     '0644'
-    owner    new_resource.owner
-    group    new_resource.group
-    variables autoregister_values
+  if node[:platform_family].include?("windows")
+    template new_resource.path do
+      source  'autoregister.properties.erb'
+      cookbook 'gocd'
+      variables autoregister_values
+    end
+  else
+    template new_resource.path do
+      source  'autoregister.properties.erb'
+      cookbook 'gocd'
+      mode     '0644'
+      owner    new_resource.owner
+      group    new_resource.group
+      variables autoregister_values
+    end
   end
 end
 


### PR DESCRIPTION
Creating autoregister files does not work on windows because of the linux specific group settings in the template resource. It throws that weird group mapping error. Adding a windows specific call to the template resource without a group parameter fixes that.