### PR TITLE
Fix slashes being passed in incorrectly when work_dir is specified

### DIFF
--- a/recipes/server_windows_install.rb
+++ b/recipes/server_windows_install.rb
@@ -7,7 +7,7 @@ end
 
 opts = []
 opts << '/S'
-opts << "/D=#{node['gocd']['server']['work_dir']}"
+opts << "/D='#{node['gocd']['server']['work_dir'].gsub('/', '\\')}'"
 
 if defined?(Chef::Provider::Package::Windows)
   package 'Go Server' do


### PR DESCRIPTION
I broke this as part of pull request #93 

If you specify work_dir with a forward slash the server will fail to install correctly. Forward slash or backward slash is valid ruby, but the gocd installer expects a backslash.