### PR TITLE
[Breaking change] Remove usages of `go_server_host` and `go_server_port`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Upcoming Release
+
+## Breaking changes
+
+* The attributes `go_server_host` and `go_server_port` are removed in favour of `go_server_url`
+
 # 1.3.2
 
 * Changes all URLs from go.cd to gocd.io.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -9,14 +9,9 @@ module Gocd
     def get_agent_properties
       values = {}
       values[:go_server_url] = node['gocd']['agent']['go_server_url']
-      values[:go_server_port] = node['gocd']['agent']['go_server_port']
       if Chef::Config['solo'] || node['gocd']['agent']['go_server_url']
         Chef::Log.info("Attempting to use node['gocd']['agent']['go_server_url'] attribute for server url")
         values[:go_server_url] = node['gocd']['agent']['go_server_url']
-        values[:key] = node['gocd']['agent']['autoregister']['key']
-      elsif Chef::Config['solo'] || node['gocd']['agent']['go_server_host']
-        Chef::Log.info("Attempting to use node['gocd']['agent']['go_server_host'] attribute for server host")
-        values[:go_server_host] = node['gocd']['agent']['go_server_host']
         values[:key] = node['gocd']['agent']['autoregister']['key']
       else
         server_search_query = node['gocd']['agent']['server_search_query']
@@ -27,6 +22,7 @@ module Gocd
         else
           go_server = go_servers.first
           values[:go_server_host] = go_server['ipaddress']
+          values[:go_server_ssl_port] = go_server['gocd']['server']['https_port']
           if go_servers.count > 1
             Chef::Log.warn("Multiple Go servers found on Chef server. Using first returned server '#{values[:go_server_host]}' for server instance configuration.")
           end
@@ -34,7 +30,7 @@ module Gocd
           if values[:key] = go_server['gocd']['server']['autoregister_key']
             Chef::Log.warn("Agent auto-registration enabled. This agent will not require approval to become active.")
           end
-          values[:go_server_url] = "https://#{go_server}:#{values[:go_server_port]}/go"
+          values[:go_server_url] = "https://#{values[:go_server_host]}:#{values[:go_server_ssl_port]}/go"
         end
       end
       values[:hostname]     = node['gocd']['agent']['autoregister']['hostname']

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -9,8 +9,6 @@ property :agent_name, :name_attribute => true, :kind_of => String, :required => 
 property :user, :kind_of => String, :required => false, :default => 'go'
 property :group, :kind_of => String, :required => false, :default => 'go'
 property :go_server_url, :kind_of => String, :required => false, :default => nil
-property :go_server_host, :kind_of => String, :required => false, :default => nil # obsolete
-property :go_server_port, :kind_of => Integer, :required => false, :default => node['gocd']['agent']['go_server_port'] # obsolete
 property :daemon, :kind_of => [ TrueClass, FalseClass ], :required => false, :default => node['gocd']['agent']['daemon']
 property :vnc, :kind_of => [ TrueClass, FalseClass ], :required => false, :default => node['gocd']['agent']['vnc']['enabled']
 property :autoregister_key, :kind_of => String, :required => false, :default => nil
@@ -22,13 +20,6 @@ property :elastic_agent_id, :kind_of => [ String, nil ], :required => false, :de
 property :elastic_agent_plugin_id, :kind_of => [ String, nil ], :required => false, :default => nil
 
 action :create do
-  if node['gocd']['agent']['go_server_host'] != nil || node['gocd']['agent']['go_server_port'] != nil
-    log "Warn obsolete attributes" do
-      message "Depreciation: node['gocd']['agent']['go_server_host'] and node['gocd']['agent']['go_server_port'] have been replaced by node['gocd']['agent']['go_server_url']"
-      level :warn
-    end
-  end
-
   include_recipe 'gocd::agent_linux_install'
 
   agent_name = new_resource.agent_name
@@ -55,8 +46,7 @@ action :create do
   autoregister_values[:workspace] = workspace
   autoregister_values[:log_directory] = log_directory
   if autoregister_values[:go_server_url].nil?
-    autoregister_values[:go_server_host] = new_resource.go_server_host || autoregister_values[:go_server_host] || 'localhost'
-    autoregister_values[:go_server_url] = "https://#{autoregister_values[:go_server_host]}:8154/go"
+    autoregister_values[:go_server_url] = "https://localhost:8154/go"
     Chef::Log.warn("Go server not found on Chef server or not specifed via node['gocd']['agent']['go_server_url'] attribute, defaulting Go server to #{autoregister_values[:go_server_url]}")
   end
 

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -20,6 +20,13 @@ property :elastic_agent_id, :kind_of => [ String, nil ], :required => false, :de
 property :elastic_agent_plugin_id, :kind_of => [ String, nil ], :required => false, :default => nil
 
 action :create do
+  if !node['gocd']['agent']['go_server_host'].nil? || !node['gocd']['agent']['go_server_port'].nil?
+    log "Warn obsolete attributes" do
+      message "Please note that node['gocd']['agent']['go_server_host'] and node['gocd']['agent']['go_server_port'] have been replaced by node['gocd']['agent']['go_server_url']"
+      level :warn
+    end
+  end
+
   include_recipe 'gocd::agent_linux_install'
 
   agent_name = new_resource.agent_name

--- a/templates/default/go-agent-default.erb
+++ b/templates/default/go-agent-default.erb
@@ -7,12 +7,7 @@ export GOCD_AGENT_WORKING_DIR=<%= @workspace %>
 export GOCD_AGENT_LOG_DIR=<%= @log_directory %>
 # export DEBUG=1 # set this environment variable to any value will turn on debug log.
 <% else %>
-<% if @go_server_url %>
 export GO_SERVER_URL=<%=  @go_server_url %>
-<% else %>
-export GO_SERVER=<%=      @go_server_host %>
-export GO_SERVER_PORT=<%= @go_server_port %>
-<% end %>
 export JAVA_HOME=<%=      node['java']['java_home'] %>
 export AGENT_WORK_DIR=<%= @workspace %>
 DAEMON=<%=  @daemon ? 'Y' : 'N' %>


### PR DESCRIPTION
* Autodetect go server ip and port in case `go_server_url` is not provided