### PR TITLE
Do not start service upon installation. 

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -7,7 +7,7 @@ end
 
 service (platform?('windows') ? 'Go Server' : 'go-server') do
   supports :status => true, :restart => true, :start => true, :stop => true
-  action [:enable, :start]
+  action [:enable]
   if node['gocd']['server']['wait_up']['retries'] != 0
     notifies :get, 'http_request[verify_go-server_comes_up]', :immediately
   end

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -2,7 +2,7 @@ actions :create, :delete
 
 default_action :create if defined?(default_action)
 
-property :service_action, :kind_of => [ Symbol, Array ], :required => false, :default => [:enable,:start]
+property :service_action, :kind_of => [ Symbol, Array ], :required => false, :default => [:enable]
 
 property :agent_name, :name_attribute => true, :kind_of => String, :required => false
 


### PR DESCRIPTION
Start service only after changes made to /etc/default/(go-server|go-agent).

As of release 17.2.0, we no longer start the service upon installation - https://github.com/gocd/gocd/commit/3b9f54b863c8df762c7927d859a9b4b45fdc4c7c